### PR TITLE
Move supporteddats.hpp to correct location

### DIFF
--- a/twpp.hpp
+++ b/twpp.hpp
@@ -57,7 +57,6 @@ SOFTWARE.
 #include "twpp/frame.hpp"
 #include "twpp/exception.hpp"
 #include "twpp/typesops.hpp"
-#include "twpp/supporteddat.hpp"
 
 #include "twpp/memoryops.hpp"
 #include "twpp/memory.hpp"
@@ -69,6 +68,7 @@ SOFTWARE.
 #include "twpp/imagelayout.hpp"
 #include "twpp/deviceevent.hpp"
 #include "twpp/element8.hpp"
+#include "twpp/supporteddat.hpp"
 
 #include "twpp/audio.hpp"
 #include "twpp/capability.hpp"


### PR DESCRIPTION
Accidentally placed in the wrong location last commit. Fixing this time. Fixed changes made in #40 .